### PR TITLE
Fix(bug): Fix `ReferenceError` and restore dashboard logic

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -62,6 +62,32 @@ function runFullProjectInitialSetup(passedSpreadsheet) {
 
     PropertiesService.getScriptProperties().setProperty(SPREADSHEET_ID_KEY, activeSS.getId());
 
+    // --- START: RESTORED DASHBOARD & JOB DATA SETUP ---
+    Logger.log(`\n[${FUNC_NAME} INFO] --- Starting Dashboard & Job Data Setup ---`);
+    try {
+        const dashboardSheet = getOrCreateDashboardSheet(activeSS);
+        const jobDataSheet = getOrCreateJobDataSheet(activeSS);
+
+        if (dashboardSheet && jobDataSheet) {
+            formatDashboardSheet(dashboardSheet);
+            setupJobDataSheetFormulas(jobDataSheet);
+            updateDashboardMetrics(dashboardSheet, jobDataSheet);
+
+            // Add success messages
+            const dashboardMsg = `Dashboard Module: Sheet setup and charts configured.`;
+            setupMessages.push(dashboardMsg);
+            Logger.log(`[${FUNC_NAME} INFO] ${dashboardMsg}`);
+
+        } else {
+            throw new Error("Failed to get or create Dashboard or Job Data sheets.");
+        }
+    } catch (e) {
+        Logger.log(`[${FUNC_NAME} CRITICAL ERROR] Dashboard setup Exception: ${e.toString()}\n${e.stack}`);
+        setupMessages.push(`Dashboard Module: CRITICAL EXCEPTION - ${e.message}`);
+        overallSuccess = false; // Mark the overall setup as failed
+    }
+    // --- END: RESTORED DASHBOARD & JOB DATA SETUP ---
+
     if (typeof TEMPLATE_SHEET_ID !== 'undefined' && TEMPLATE_SHEET_ID !== "" && activeSS.getId() === TEMPLATE_SHEET_ID) {
         const templateMsg = `[${FUNC_NAME} INFO] Target spreadsheet is the TEMPLATE. Setup SKIPPED.`;
         Logger.log(templateMsg);

--- a/ModuleUtils.js
+++ b/ModuleUtils.js
@@ -3,6 +3,7 @@ function _setupModule(config) {
   Logger.log(`\n==== ${FUNC_NAME}: STARTING - ${config.moduleName} Module Setup ====`);
   let messages = [];
   let moduleSuccess = true;
+  let dataSh; // This will hold the sheet object for the module
 
   if (!config.activeSS || typeof config.activeSS.getId !== 'function') {
     const errMsg = "CRITICAL: Invalid spreadsheet object passed.";
@@ -14,7 +15,7 @@ function _setupModule(config) {
 
   // Setup module-specific sheet
   try {
-    let dataSh = activeSS.getSheetByName(config.sheetTabName);
+    dataSh = activeSS.getSheetByName(config.sheetTabName);
     if (!dataSh) {
       dataSh = activeSS.insertSheet(config.sheetTabName);
       Logger.log(`[${FUNC_NAME} INFO] Created new sheet: "${config.sheetTabName}".`);


### PR DESCRIPTION
This commit addresses a critical bug that prevented the initial setup from completing and restores the logic that creates the 'Dashboard' and its related 'Job Data' sheet.

The following changes were made:
- In `ModuleUtils.js`, the `dataSh` variable is now declared in a higher scope to prevent a `ReferenceError`.
- In `Main.js`, the dashboard creation and formatting logic has been restored in the `runFullProjectInitialSetup` function.